### PR TITLE
add fips snap build

### DIFF
--- a/branches/build-snapd-snap/target/tasks/build-snapd-snap/task.yaml
+++ b/branches/build-snapd-snap/target/tasks/build-snapd-snap/task.yaml
@@ -42,3 +42,16 @@ execute: |
 
     mv snapd_*.snap "$SNAP_NAME"
     gsutil cp "$SNAP_NAME" "$BUCKET_FILE"
+
+    if uname -m | grep -Eq '(aarch64.*|armv8.*)'; then
+        exit 0
+    fi
+
+    touch fips-build
+    snapcraft --use-lxd
+
+    SNAP_NAME="${SNAP_NAME%.snap}-fips.snap"
+    BUCKET_FILE="gs://snapd-spread-tests/snapd-tests/snaps/$SNAP_NAME"
+
+    mv snapd_*.snap "$SNAP_NAME"
+    gsutil cp "$SNAP_NAME" "$BUCKET_FILE"


### PR DESCRIPTION
We use snapd snap built here for running various workflows: nightly tests, feature tagging. This adds building a fips variant as well. Following this, I will update spread-tests.yaml in snapd to use the new fips snap variant for fips testing